### PR TITLE
Fix variable name for mismatched genre mapping

### DIFF
--- a/outlier_mnli.ipynb
+++ b/outlier_mnli.ipynb
@@ -774,7 +774,7 @@
     "genre_labels = np.array([labels_dict.get(x, 0) for x in selected_outlier_subset[\"genre\"]])\n",
     "for i, genre in enumerate(labels_dict.keys()):\n",
     "    x, y = x_plot[genre_labels == i], y_plot[genre_labels == i]\n",
-    "    if genre in mismatched_genres:\n",
+    "    if genre in genre_labels:\n",
     "        plt.scatter(x, y, label=genre)\n",
     "    else:\n",
     "        plt.scatter(x, y, label=genre, alpha=0.5, marker=\"^\")\n",

--- a/outlier_mnli.ipynb
+++ b/outlier_mnli.ipynb
@@ -774,7 +774,7 @@
     "genre_labels = np.array([labels_dict.get(x, 0) for x in selected_outlier_subset[\"genre\"]])\n",
     "for i, genre in enumerate(labels_dict.keys()):\n",
     "    x, y = x_plot[genre_labels == i], y_plot[genre_labels == i]\n",
-    "    if genre in genre_labels:\n",
+    "    if genre in mismatched_labels:\n",
     "        plt.scatter(x, y, label=genre)\n",
     "    else:\n",
     "        plt.scatter(x, y, label=genre, alpha=0.5, marker=\"^\")\n",


### PR DESCRIPTION
Line777: list `mismatched_genres` is not defined.
list `genre_labels` would be the list instead, intuitively.